### PR TITLE
Crash on convert_data for "craft"

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -51,12 +51,14 @@ local function convert_data()
 			local ret = {}
 
 			local count = 0
-			for modname, items in pairs(data[from]) do
-				for itemname, value in pairs(items) do
-					itemname = modname .. ":" .. itemname
-					local key = minetest.registered_aliases[itemname] or itemname
-					ret[key] = value
-					count = count + value
+			if data[from] then
+				for modname, items in pairs(data[from]) do
+					for itemname, value in pairs(items) do
+						itemname = modname .. ":" .. itemname
+						local key = minetest.registered_aliases[itemname] or itemname
+						ret[key] = value
+						count = count + value
+					end
 				end
 			end
 


### PR DESCRIPTION
I've just updated to the latest version, wich triggered the data conversion from the old format. Sadly it crashed:
```
2018-04-23 17:16:20: ERROR[Main]: ModError: Failed to load and run script from /home/minetest/public-2018/minetest/bin/../mods/awards/init.lua:
2018-04-23 17:16:20: ERROR[Main]: ...minetest/public-2018/minetest/bin/../mods/awards/api.lua:54: bad argument #1 to 'pairs' (table expected, got nil)
2018-04-23 17:16:20: ERROR[Main]: stack traceback:
2018-04-23 17:16:20: ERROR[Main]: 	[C]: in function 'pairs'
2018-04-23 17:16:20: ERROR[Main]: 	...minetest/public-2018/minetest/bin/../mods/awards/api.lua:54: in function 'convert_data'
2018-04-23 17:16:20: ERROR[Main]: 	...minetest/public-2018/minetest/bin/../mods/awards/api.lua:79: in function 'load'
2018-04-23 17:16:20: ERROR[Main]: 	...minetest/public-2018/minetest/bin/../mods/awards/api.lua:496: in main chunk
2018-04-23 17:16:20: ERROR[Main]: 	[C]: in function 'dofile'
2018-04-23 17:16:20: ERROR[Main]: 	...inetest/public-2018/minetest/bin/../mods/awards/init.lua:13: in main chunk
```
I added some additional logging and found it to only crash when from="craft", while "place" and "count" conversion worked. So it looks like my previous awards version didn't count crafts and there was no such data. With an additional check in place the convesation succeeded:
```
if data[from] then
                        for modname, items in pairs(data[from]) do
                                for itemname, value in pairs(items) do
                                        itemname = modname .. ":" .. itemname
                                        local key = minetest.registered_aliases[itemname] or itemname
                                        ret[key] = value
                                        count = count + value
                                end
                        end
end
```
Was my previous version just too old or should such a check be adopted in the mod's code?