### PR TITLE
Add kill_mob and punch_entity triggers

### DIFF
--- a/awards.lua
+++ b/awards.lua
@@ -958,3 +958,35 @@ if minetest.get_modpath("nyancat") then
 		}
 	})
 end
+
+if minetest.get_modpath("mobs_animal") then
+	awards.register_award("mobs:kill_chicken", {
+		title = S("Chicken"),
+		description = S("A test award when mobs mod on"),
+		difficulty = 0.001,
+		trigger = {
+			type = "kill_mob",
+			mob = "mobs_animal:chicken",
+			target = 5
+		}
+	})
+	awards.register_award("mobs:kill_cow", {
+		title = S("Cows"),
+		description = S("A test award when mobs mod on"),
+		difficulty = 0.001,
+		trigger = {
+			type = "kill_mob",
+			mob = "mobs_animal:cow",
+			target = 5
+		}
+	})
+	awards.register_award("mobs:kill_all", {
+		title = S("All"),
+		description = S("A test award when mobs mod on"),
+		difficulty = 0.001,
+		trigger = {
+			type = "kill_mob",
+			target = 5
+		}
+	})
+end

--- a/awards.lua
+++ b/awards.lua
@@ -990,3 +990,13 @@ if minetest.get_modpath("mobs_animal") then
 		}
 	})
 end
+
+awards.register_award("pnch_entity_test", {
+	title = S("All"),
+	description = S("A test award for punching"),
+	difficulty = 0.001,
+	trigger = {
+		type = "punch_entity",
+		target = 5
+	}
+})

--- a/depends.txt
+++ b/depends.txt
@@ -12,3 +12,4 @@ moreblocks?
 fire?
 flowers?
 nyancat?
+mobs_animal?

--- a/triggers.lua
+++ b/triggers.lua
@@ -172,7 +172,7 @@ end)
 -- trigger for killing an entity
 awards.register_trigger("punch_entity", {
 	type = "counted_key",
-	progress = "@1/@2 killed",
+	progress = "@1/@2 punched",
 	auto_description = { "Punch @2", "Punch @1×@2" },
 	auto_description_total = { "Punch @1 entity", "Punch @1 entities." },
 	get_key = function(self, def)


### PR DESCRIPTION
New triggers on killing mobs and punching entities
When a mob is punched, there is a check to know if the mob is still alive. If its health is under 0, the trigger is triggered.
For entity, each time an entity is punched, the trigger is triggered.
There are also test awards to validate the kill_mob trigger, should be removed in release, or at least enhance with good description.

Note : A mob is also an entity, but the punch_entity is not triggered when punching a mob
