### PR TITLE
Fix crash for invalid award index selection

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -79,20 +79,20 @@ function awards.get_formspec(name, to, sid)
 
 	-- Sidebar
 	local sitem = awards_list[sid]
-	local def = sitem.def
-	if def and def.secret and not sitem.unlocked then
+	local sdef = sitem.def
+	if sdef and sdef.secret and not sitem.unlocked then
 		formspec = formspec .. "label[1,2.75;"..
 				minetest.formspec_escape(S("(Secret Award)")).."]"..
 				"image[1,0;3,3;awards_unknown.png]"
-		if def and def.description then
+		if sdef and sdef.description then
 			formspec = formspec	.. "textarea[0.25,3.25;4.8,1.7;;"..
 					minetest.formspec_escape(
 							S("Unlock this award to find out what it is."))..";]"
 		end
 	else
 		local title = sitem.name
-		if def and def.title then
-			title = def.title
+		if sdef and sdef.title then
+			title = sdef.title
 		end
 		local status = "%s"
 		if sitem.unlocked then
@@ -103,14 +103,14 @@ function awards.get_formspec(name, to, sid)
 			string.format(status, minetest.formspec_escape(title)) ..
 			";]"
 
-		if def and def.icon then
-			formspec = formspec .. "image[1,0;3,3;" .. def.icon .. "]"
+		if sdef and sdef.icon then
+			formspec = formspec .. "image[1,0;3,3;" .. sdef.icon .. "]"
 		end
 		local barwidth = 4.6
 		local perc = nil
 		local label = nil
-		if def.getProgress and data then
-			local res = def:getProgress(data)
+		if sdef.getProgress and data then
+			local res = sdef:getProgress(data)
 			perc = res.perc
 			label = res.label
 		end
@@ -124,8 +124,8 @@ function awards.get_formspec(name, to, sid)
 				formspec = formspec .. "label[1.75,4.63;" .. minetest.formspec_escape(label) .. "]"
 			end
 		end
-		if def and def.description then
-			formspec = formspec	.. "textarea[0.25,3.75;4.8,1.7;;"..minetest.formspec_escape(def.description)..";]"
+		if sdef and sdef.description then
+			formspec = formspec	.. "textarea[0.25,3.75;4.8,1.7;;"..minetest.formspec_escape(sdef.description)..";]"
 		end
 	end
 

--- a/gui.lua
+++ b/gui.lua
@@ -75,59 +75,57 @@ function awards.get_formspec(name, to, sid)
 		formspec = formspec .. "button_exit[4.2,2.3;3,1;close;"..minetest.formspec_escape(S("OK")).."]"
 		return formspec
 	end
+	sid = awards_list[sid] and sid or 1
 
 	-- Sidebar
-	if sid then
-		local item = awards_list[sid+0]
-		local def  = item.def
+	local sitem = awards_list[sid]
+	local def = sitem.def
+	if def and def.secret and not sitem.unlocked then
+		formspec = formspec .. "label[1,2.75;"..
+				minetest.formspec_escape(S("(Secret Award)")).."]"..
+				"image[1,0;3,3;awards_unknown.png]"
+		if def and def.description then
+			formspec = formspec	.. "textarea[0.25,3.25;4.8,1.7;;"..
+					minetest.formspec_escape(
+							S("Unlock this award to find out what it is."))..";]"
+		end
+	else
+		local title = sitem.name
+		if def and def.title then
+			title = def.title
+		end
+		local status = "%s"
+		if sitem.unlocked then
+			status = S("%s (unlocked)")
+		end
 
-		if def and def.secret and not item.unlocked then
-			formspec = formspec .. "label[1,2.75;"..
-					minetest.formspec_escape(S("(Secret Award)")).."]"..
-					"image[1,0;3,3;awards_unknown.png]"
-			if def and def.description then
-				formspec = formspec	.. "textarea[0.25,3.25;4.8,1.7;;"..
-						minetest.formspec_escape(
-								S("Unlock this award to find out what it is."))..";]"
-			end
-		else
-			local title = item.name
-			if def and def.title then
-				title = def.title
-			end
-			local status = "%s"
-			if item.unlocked then
-				status = S("%s (unlocked)")
-			end
+		formspec = formspec .. "textarea[0.5,2.7;4.8,1.45;;" ..
+			string.format(status, minetest.formspec_escape(title)) ..
+			";]"
 
-			formspec = formspec .. "textarea[0.5,2.7;4.8,1.45;;" ..
-				string.format(status, minetest.formspec_escape(title)) ..
-				";]"
-
-			if def and def.icon then
-				formspec = formspec .. "image[1,0;3,3;" .. def.icon .. "]"
+		if def and def.icon then
+			formspec = formspec .. "image[1,0;3,3;" .. def.icon .. "]"
+		end
+		local barwidth = 4.6
+		local perc = nil
+		local label = nil
+		if def.getProgress and data then
+			local res = def:getProgress(data)
+			perc = res.perc
+			label = res.label
+		end
+		if perc then
+			if perc > 1 then
+				perc = 1
 			end
-			local barwidth = 4.6
-			local perc = nil
-			local label = nil
-			if def.getProgress and data then
-				local res = def:getProgress(data)
-				perc = res.perc
-				label = res.label
+			formspec = formspec .. "background[0,4.80;" .. barwidth ..",0.25;awards_progress_gray.png;false]"
+			formspec = formspec .. "background[0,4.80;" .. (barwidth * perc) ..",0.25;awards_progress_green.png;false]"
+			if label then
+				formspec = formspec .. "label[1.75,4.63;" .. minetest.formspec_escape(label) .. "]"
 			end
-			if perc then
-				if perc > 1 then
-					perc = 1
-				end
-				formspec = formspec .. "background[0,4.80;" .. barwidth ..",0.25;awards_progress_gray.png;false]"
-				formspec = formspec .. "background[0,4.80;" .. (barwidth * perc) ..",0.25;awards_progress_green.png;false]"
-				if label then
-					formspec = formspec .. "label[1.75,4.63;" .. minetest.formspec_escape(label) .. "]"
-				end
-			end
-			if def and def.description then
-				formspec = formspec	.. "textarea[0.25,3.75;4.8,1.7;;"..minetest.formspec_escape(def.description)..";]"
-			end
+		end
+		if def and def.description then
+			formspec = formspec	.. "textarea[0.25,3.75;4.8,1.7;;"..minetest.formspec_escape(def.description)..";]"
 		end
 	end
 
@@ -199,9 +197,6 @@ function awards.show_to(name, to, sid, text)
 			end
 		end
 	else
-		if sid == nil or sid < 1 then
-			sid = 1
-		end
 		local deco = ""
 		if minetest.global_exists("default") then
 			deco = default.gui_bg .. default.gui_bg_img
@@ -226,7 +221,7 @@ if minetest.get_modpath("sfinv") then
 		get = function(self, player, context)
 			local name = player:get_player_name()
 			return sfinv.make_formspec(player, context,
-				awards.get_formspec(name, name, context.awards_idx or 1),
+				awards.get_formspec(name, name, context.awards_idx),
 				false, "size[11,5]")
 		end,
 		on_player_receive_fields = function(self, player, context, fields)


### PR DESCRIPTION
Sending the key/value pair `awards,CHG:999` to the formspec `awards:awards` can crash servers due to nil `item`.