### PR TITLE
Fix group total, fix item increment count argument, others

### DIFF
--- a/src/api_awards.lua
+++ b/src/api_awards.lua
@@ -43,6 +43,10 @@ end
 -- name - the name of the player
 -- award - the name of the award to give
 function awards.unlock(name, award)
+	if not minetest.get_player_by_name(name) or not minetest.get_player_by_name(name):is_player() then
+		return
+	end
+
 	-- Access Player Data
 	local data  = awards.player(name)
 	local awdef = awards.registered_awards[award]
@@ -60,7 +64,7 @@ function awards.unlock(name, award)
 	end
 
 	-- Unlock Award
-	minetest.log("action", name.." has unlocked award "..name)
+	minetest.log("action", name.." has unlocked award "..award)
 	data.unlocked[award] = award
 	awards.save()
 
@@ -91,7 +95,7 @@ function awards.unlock(name, award)
 	local title = awdef.title or award
 	local desc = awdef.description or ""
 	local background = awdef.background or "awards_bg_default.png"
-	local icon = awdef.icon or "awards_unknown.png"
+	local icon = awdef.icon.."^[resize:16x16" or "awards_unknown.png"
 	local sound = awdef.sound
 	if sound == nil then
 		-- Explicit check for nil because sound could be `false` to disable it

--- a/src/api_triggers.lua
+++ b/src/api_triggers.lua
@@ -62,6 +62,9 @@ function awards.register_trigger(tname, tdef)
 		end
 
 		function tdef.notify(player)
+			if not player:is_player() or not minetest.get_player_by_name(player:get_player_name()) then
+				return
+			end
 			assert(player and player.is_player and player:is_player())
 			local name = player:get_player_name()
 			local data = awards.player(name)
@@ -152,6 +155,10 @@ function awards.register_trigger(tname, tdef)
 				end
 			end
 
+			if not player:is_player() or not minetest.get_player_by_name(player:get_player_name()) then
+				return
+			end
+
 			assert(player and player.is_player and player:is_player() and key)
 			local name = player:get_player_name()
 			local data = awards.player(name)
@@ -160,8 +167,9 @@ function awards.register_trigger(tname, tdef)
 			data[tname] = data[tname] or {}
 			local currentVal = (data[tname][key] or 0) + n
 			data[tname][key] = currentVal
+			data[tname].__total = (data[tname].__total or 0)
 			if key:sub(1, 6) ~= "group:" then
-				data[tname].__total = (data[tname].__total or 0) + n
+				data[tname].__total = data[tname].__total + n
 			end
 
 			tdef:run_callbacks(player, data, function(entry)
@@ -173,7 +181,6 @@ function awards.register_trigger(tname, tdef)
 				else
 					return
 				end
-
 				if current >= entry.target then
 					return entry.award
 				end
@@ -201,7 +208,7 @@ end
 
 function awards.increment_item_counter(data, field, itemname, count)
 	itemname = minetest.registered_aliases[itemname] or itemname
-	data[field][itemname] = (data[field][itemname] or 0) + 1
+	data[field][itemname] = (data[field][itemname] or 0) + (count or 1)
 end
 
 function awards.get_item_count(data, field, itemname)

--- a/src/triggers.lua
+++ b/src/triggers.lua
@@ -137,5 +137,5 @@ minetest.register_on_item_eat(function(_, _, itemstack, player, _)
 
 	local itemname = itemstack:get_name()
 	itemname = minetest.registered_aliases[itemname] or itemname
-	awards.notify_craft(player, itemname, itemstack:get_count())
+	awards.notify_eat(player, itemname)
 end)


### PR DESCRIPTION
This PR does a lot in one.  
* Fixes `__total` on `group:` increments
* Uses the `count` argument in `awards.increment_item_counter`
* Makes sure player is a player before running functions that could fail if it is a fake player
* Resizes the icon on the award notification to always fit
* Fixes a log output (using new variable)

I know the player checks are lengthy, but I don't know if `minetest.is_player()` can be used. If it can, please let me know; I will change it.