### PR TITLE
prevent crash when a non-player object digs a node

### DIFF
--- a/src/api_triggers.lua
+++ b/src/api_triggers.lua
@@ -152,7 +152,9 @@ function awards.register_trigger(tname, tdef)
 				end
 			end
 
-			assert(player and player.is_player and player:is_player() and key)
+			if not (player and player.is_player and player:is_player() and key) then
+				return
+			end
 			local name = player:get_player_name()
 			local data = awards.player(name)
 


### PR DESCRIPTION
This fixes https://github.com/rubenwardy/awards/issues/59, which is preventing compatibility between awards and the Digtron mod.